### PR TITLE
CGAsset Defaults - Stream, Step & Variant

### DIFF
--- a/grill/tokens/ids/CGAsset.cfg
+++ b/grill/tokens/ids/CGAsset.cfg
@@ -25,7 +25,7 @@ description = Contributions sharing same workflows of a pipeline (e.g. 'edit', '
 
 [stream]
 short_name = sm
-default = lead
+default = main
 description = Stream where the contribution is being worked on (e.g. 'wip', 'test').
 
 [item]
@@ -35,12 +35,12 @@ description = Atomic unit that makes sense on its own from its contributions (e.
 
 [step]
 short_name = sp
-default = main
+default = lead
 description = Inner process of the current `area` during the life cycle of a contribution (e.g. 'cleanup', 'blocking').
 
 [variant]
 short_name = v
-default = all
+default = root
 description = Variation expressing a different intent of the current `item` (e.g. 'wet', 'optionB', 'grayscale').
 
 [part]

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -12,26 +12,26 @@ class TestNames(unittest.TestCase):
         self.assertEqual(name.area, 'model')
         path = Path.joinpath(
             Path(),
-            'demo', '3d', 'abc', 'entity', 'model', 'lead', 'atom', 'main', 'all',
-            'whole', '1', 'demo-3d-abc-entity-model-lead-atom-main-all-whole.1.ext'
+            'demo', '3d', 'abc', 'entity', 'model', 'main', 'atom', 'lead', 'root',
+            'whole', '1', 'demo-3d-abc-entity-model-main-atom-lead-root-whole.1.ext'
         )
         self.assertEqual(Path(path), name.path)
         name.sep = ':'
         self.assertEqual(':', name.sep)
-        self.assertEqual('demo:3d:abc:entity:model:lead:atom:main:all:whole.1.ext', name.get())
+        self.assertEqual('demo:3d:abc:entity:model:main:atom:lead:root:whole.1.ext', name.get())
         name.sep = '.'
         self.assertEqual(name.sep, '.')
-        self.assertEqual('demo.3d.abc.entity.model.lead.atom.main.all.whole.1.ext', name.get())
+        self.assertEqual('demo.3d.abc.entity.model.main.atom.lead.root.whole.1.ext', name.get())
         name.sep = ' '
         name.name = name.get(area='rig', part='leg', output='skin', stream='dev')
         self.assertEqual('rig', name.area)
-        self.assertEqual('demo 3d abc entity rig dev atom main all leg.skin.1.ext', name.get())
+        self.assertEqual('demo 3d abc entity rig dev atom lead root leg.skin.1.ext', name.get())
 
     def test_cgasset(self):
         self.assertEqual(CGAsset().get(),
                          '{code}-{media}-{kingdom}-{cluster}-{area}-{stream}-{item}-{step}-{variant}-{part}')
         self.assertEqual(CGAsset.get_default().name,
-                         'demo-3d-abc-entity-rnd-lead-atom-main-all-whole')
+                         'demo-3d-abc-entity-rnd-main-atom-lead-root-whole')
 
     def test_lifetr(self):
         domain = 'Eukarya'


### PR DESCRIPTION
Updated CGAsset defaults:

- stream = main
- step = lead
- variant = root