### PR TITLE
Python-3.14 on CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,11 +10,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.13", "3.13t"]
+        python-version: ["3.9", "3.14", "3.14t"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}
-        uses: Quansight-Labs/setup-python@v5 # until https://github.com/actions/setup-python/issues/771 is resolved
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up Graphviz
@@ -26,7 +26,7 @@ jobs:
           python -m pip install .
       - name: Test
         run: |
-          pytest --cov .
+          PYTHONWARNINGS=error pytest --cov --durations=10 .
         # https://github.com/marketplace/actions/codecov
       - name: Codecov Report
         uses: codecov/codecov-action@v4

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,3 +12,6 @@ python:
       path: .
       extra_requirements:
         - docs
+
+sphinx:
+  configuration: docs/source/conf.py

--- a/grill/tokens/ids/__init__.py
+++ b/grill/tokens/ids/__init__.py
@@ -1,3 +1,4 @@
+import sys
 import enum
 import typing
 import configparser
@@ -23,7 +24,8 @@ def __getattr__(name):
 
 
 def __dir__():
+    # TODO: remove args when in Python-3.12+
+    args = ((__name__,) if sys.version_info < (3, 12) else tuple())
     return tuple(
-        # how to do better?
-        c.split('.cfg')[0] for c in resources.contents(__name__) if c.endswith('.cfg')
+        cfg.stem for cfg in resources.files(*args).glob('*.cfg')
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,13 +8,14 @@ keywords = naming convention cg
 author_email = chris.gfz@gmail.com
 author = Christian López Barrón
 url = https://github.com/thegrill/grill-names
+# Align with https://devguide.python.org/versions/
 classifiers =
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 
 [options]
 install_requires = naming>=0.6


### PR DESCRIPTION
- CI python range is now 3.9 -> 3.14 & 3.14t
- Added slow tests durations report
- Enabled warnings as errors